### PR TITLE
Replaces getDatabaseConnection function

### DIFF
--- a/Classes/Updates/v76/LanguageIsoCodeUpdate.php
+++ b/Classes/Updates/v76/LanguageIsoCodeUpdate.php
@@ -72,7 +72,7 @@ class LanguageIsoCodeUpdate implements UpgradeWizardInterface
             ->executeQuery()
             ->fetchOne();
 
-        return true;
+        return $migratableLanguageRecordsCount > 0;
     }
 
     /**


### PR DESCRIPTION
When static_info_tables is installed, the following error message is displayed:
```
Uncaught TYPO3 Exception Call to undefined method TYPO3\CMS\v76\Install\Updates\LanguageIsoCodeUpdate::getDatabaseConnection()
thrown in file /var/www/html/vendor/wapplersystems/core-upgrader/Classes/Updates/v76/LanguageIsoCodeUpdate.php
in line 59
```

The method getDatabaseConnection has been deprecated since version 8 and removed since version 9.
I have now attempted this fix.

Best regards and thank you for your work